### PR TITLE
docs: archival banner — 2-monorepo migration housekeeping (SGE-1341)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-> ⚠️ **Status: Queued for archive (2026-06 org consolidation).** No new work should land here. This fork is retained for historical reference and is archived in favour of upstream https://github.com/citrineos/citrineos-core. See the housekeeping issue for details.
+> ℹ️ **This is a fork maintained for reference.** Active development happens in our internal platform; issues/PRs here are not actively triaged.
+> _Review pass 2026-06-25: confirmed this is a public fork of the upstream open-source OCPP 2.0.1 EV charging station runtime; no 7GenCap-specific logic found in the repository._
 
 ![CitrineOS Logo](logo_white.png#gh-dark-mode-only)
 ![CitrineOS Logo](logo_black.png#gh-light-mode-only)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > ℹ️ **This is a fork maintained for reference.** Active development happens in our internal platform; issues/PRs here are not actively triaged.
-> _Review pass 2026-06-25: confirmed this is a public fork of the upstream open-source OCPP 2.0.1 EV charging station runtime; no 7GenCap-specific logic found in the repository._
+> _Review pass 2026-06-25: confirmed this is a public fork of the upstream open-source OCPP 2.0.1 EV charging station runtime; no proprietary internal logic found; this is a clean upstream fork._
 
 ![CitrineOS Logo](logo_white.png#gh-dark-mode-only)
 ![CitrineOS Logo](logo_black.png#gh-light-mode-only)


### PR DESCRIPTION
## Summary

Housekeeping banner PR — part of the 2026-06 2-monorepo migration wave (continues the 2026-06-09 pass).

- Applies template **E-public-fork-generic** to the README, replacing the prior ad-hoc archive notice.
- Banner confirms this is a public fork maintained for reference only; issues/PRs here are not actively triaged.
- Review pass note dated 2026-06-25 appended inline.

**Authored by dvaladares. Needs Frans's human bless before merge. Do NOT merge, self-approve, or enable auto-merge.**

Tracking: SGE-1341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s status notice with a clearer fork-maintenance/reference message.
  * Added a review note confirming the fork status and that no 7GenCap-specific logic is included.
  * Replaced the previous archived/consolidation warning and historical archive link with the new wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->