### PR TITLE
docs: status banner (monorepo consolidation reference)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-## Status - 2026-07-22 (7Gen monorepo consolidation)
+## Status - 2026-07-22
 
-REFERENCE FORK (CitrineOS CSMS, OCPP 1.6/2.0.1). Pristine fork, zero 7Gen modifications, nothing in the platform references it (verified 2026-07-21). Archive-ready once the fold plan gains its one-line manifest entry.
-
-Platform consolidation target: https://github.com/7GenCap/7gen (see docs/monorepo-fold-plan.md there). This banner is the durable reference for why this repo looks the way it does.
+Reference fork (CitrineOS CSMS, OCPP 1.6/2.0.1). This is a pristine fork of the upstream project with zero 7Gen modifications (verified 2026-07-21). It is kept for reference only. Issues and PRs here are not triaged. Active development happens in 7Gen's internal platform.
 
 ![CitrineOS Logo](logo_white.png#gh-dark-mode-only)
 ![CitrineOS Logo](logo_black.png#gh-light-mode-only)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-> ℹ️ **This is a fork maintained for reference.** Active development happens in our internal platform; issues/PRs here are not actively triaged.
-> _Review pass 2026-06-25: confirmed this is a public fork of the upstream open-source OCPP 2.0.1 EV charging station runtime; no proprietary internal logic found; this is a clean upstream fork._
+## Status - 2026-07-22 (7Gen monorepo consolidation)
+
+REFERENCE FORK (CitrineOS CSMS, OCPP 1.6/2.0.1). Pristine fork, zero 7Gen modifications, nothing in the platform references it (verified 2026-07-21). Archive-ready once the fold plan gains its one-line manifest entry.
+
+Platform consolidation target: https://github.com/7GenCap/7gen (see docs/monorepo-fold-plan.md there). This banner is the durable reference for why this repo looks the way it does.
 
 ![CitrineOS Logo](logo_white.png#gh-dark-mode-only)
 ![CitrineOS Logo](logo_black.png#gh-light-mode-only)


### PR DESCRIPTION
Durable status banner per Daniel's 2026-07-21 directive. Status text from the verified fold scrub. README-only diff.